### PR TITLE
Fix CMakefile to properly recognize OSX version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ config.status
 configure
 *.config
 install-sh
+qmake.sh

--- a/ParadisEO-2.0.1/cmake/Config.cmake
+++ b/ParadisEO-2.0.1/cmake/Config.cmake
@@ -6,7 +6,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     # detect OS X version. (use '/usr/bin/sw_vers -productVersion' to extract V from '10.V.x'.)
     execute_process (COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
-    string(REGEX REPLACE "10\\.([0-9]).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
+    string(REGEX REPLACE "10\\.([0-9]+).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
     if(${MACOSX_VERSION} LESS 5)
         message(FATAL_ERROR "Unsupported version of OS X : ${MACOSX_VERSION_RAW}")
         return()


### PR DESCRIPTION
solves problem when compiling on OS X 10.11.2 (El Capitan)