### PR TITLE
Fix compilation with Qt 5.8

### DIFF
--- a/OMOptim/Core/Util/StringHandler.cpp
+++ b/OMOptim/Core/Util/StringHandler.cpp
@@ -1043,7 +1043,7 @@ QStringList StringHandler::unparseStrings(QString value)
         i++;
       continue;
     }
-    while (value[i] != '"' && value[i] != '\0') {
+    while (value[i] != '"' && !value[i].isNull()) {
       i++;
       fprintf(stderr, "error? malformed string-list. skipping: %c\n", value[i].toAscii());
     }


### PR DESCRIPTION
Compiling OMOptim with Qt 5.8 fails with the build error:

```
../Core/Util/StringHandler.cpp:1046:40: Error: ambiguous overload for »operator!=« (operand types are »QCharRef« and »char«)
     while (value[i] != '"' && value[i] != '\0') {
```

I would suggest using the `QChar::isNull()` method for the null character check, which should also [work with Qt 4](http://doc.qt.io/qt-4.8/qchar.html#isNull).