### PR TITLE
Improve include file handling a bit.

### DIFF
--- a/OMOptim/Core/ModPlusExeCtrl.cpp
+++ b/OMOptim/Core/ModPlusExeCtrl.cpp
@@ -5,7 +5,7 @@
 #include "MOParameter.h"
 #include "Variable.h"
 #include "ModItemsTree.h"
-#include "ModPlusOMCtrl.h"
+#include "OpenModelica/ModPlusOMCtrl.h"
 #include "PlugInterface.h"
 #include <QDebug>
 #include "LowTools.h"

--- a/OMOptim/Core/ModelPlus.cpp
+++ b/OMOptim/Core/ModelPlus.cpp
@@ -74,7 +74,7 @@
 #include "Load.h"
 #include "Save.h"
 #include "ModPlusCtrl.h"
-//#include "ModPlusOMCtrl.h"
+//#include "OpenModelica/ModPlusOMCtrl.h"
 //#include "ModPlusDymolaCtrl.h"
 #include "MOParametersDlg.h"
 #include "Project.h"

--- a/OMOptim/Core/Modelica/ModPlusCtrls.cpp
+++ b/OMOptim/Core/Modelica/ModPlusCtrls.cpp
@@ -1,6 +1,6 @@
 #include "ModPlusCtrls.h"
 
-#include "ModPlusOMCtrl.h"
+#include "OpenModelica/ModPlusOMCtrl.h"
 #include "ModPlusDymolaCtrl.h"
 #include "ModPlusOMExeCtrl.h"
 #include "ModPlusDymolaExeCtrl.h"

--- a/OMOptim/Core/OMOptimSettings.cpp
+++ b/OMOptim/Core/OMOptimSettings.cpp
@@ -41,7 +41,7 @@
 
 #include "OMOptimSettings.h"
 #include "Dymola.h"
-#include "OpenModelica.h"
+#include "OpenModelica/OpenModelica.h"
 
 void OMOptimSettings::initialize()
 {

--- a/OMOptim/Core/OpenModelica/ModPlusOMCtrl.cpp
+++ b/OMOptim/Core/OpenModelica/ModPlusOMCtrl.cpp
@@ -38,13 +38,13 @@ http://www-cep.ensmp.fr/english/
 
 
 */
-#include "ModPlusOMCtrl.h"
+#include "OpenModelica/ModPlusOMCtrl.h"
 #include "ModModelPlus.h"
 #include "ModModel.h"
 #include "MOParameter.h"
 #include "Project.h"
 #include "LowTools.h"
-#include "OpenModelicaParameters.h"
+#include "OpenModelica/OpenModelicaParameters.h"
 
 ModPlusOMCtrl::ModPlusOMCtrl(Project* project,ModModelPlus* modModelPlus,MOomc* moomc)
     :ModPlusCtrl(project,modModelPlus,moomc)

--- a/OMOptim/Core/OpenModelica/OpenModelica.cpp
+++ b/OMOptim/Core/OpenModelica/OpenModelica.cpp
@@ -42,11 +42,11 @@ http://www-cep.ensmp.fr/english/
 
 
 
-#include "OpenModelica.h"
-#include "ModPlusOMCtrl.h"
+#include "OpenModelica/OpenModelica.h"
+#include "OpenModelica/ModPlusOMCtrl.h"
 #include "VariableType.h"
 #include "LowTools.h"
-#include "OpenModelicaParameters.h"
+#include "OpenModelica/OpenModelicaParameters.h"
 #include "omc_config.h"
 #include "Utilities.h"
 

--- a/OMOptim/Core/Tools/ModPlusOMExeCtrl.cpp
+++ b/OMOptim/Core/Tools/ModPlusOMExeCtrl.cpp
@@ -1,13 +1,13 @@
 
 
-#include "ModPlusOMCtrl.h"
+#include "OpenModelica/ModPlusOMCtrl.h"
 #include "ModPlusOMExeCtrl.h"
-#include "OpenModelica.h"
+#include "OpenModelica/OpenModelica.h"
 #include "LowTools.h"
 #include "Project.h"
 #include "ModItemsTree.h"
 #include "ExeModel.h"
-#include "OpenModelicaParameters.h"
+#include "OpenModelica/OpenModelicaParameters.h"
 #include "Utilities.h"
 
 ModPlusOMExeCtrl::ModPlusOMExeCtrl(Project* project,ModelPlus* model)

--- a/OMOptim/GUI/MainWindow.cpp
+++ b/OMOptim/GUI/MainWindow.cpp
@@ -27,7 +27,7 @@
 #include "scriptparseromoptim.h"
 #include "Dialogs/HelpDlg.h"
 #include "ScriptTextDlg.h"
-#include "OpenModelica.h"
+#include "OpenModelica/OpenModelica.h"
 
 namespace Ui
 {

--- a/OMOptim/GUI/MainWindow.h
+++ b/OMOptim/GUI/MainWindow.h
@@ -73,7 +73,7 @@
 #include "Widgets/WidgetProgress.h"
 #include "Widgets/WidgetSelectModModel.h"
 #include "AboutOMOptim.h"
-#include "OpenModelica.h"
+#include "OpenModelica/OpenModelica.h"
 #include "OMCases.h"
 #include "ProblemInterface.h"
 #include "MyTreeView.h"

--- a/OMOptim/build/OMOptimLib.pro
+++ b/OMOptim/build/OMOptimLib.pro
@@ -7,18 +7,6 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     QT *= printsupport widgets webkitwidgets
 }
 
-CONFIG(debug, debug|release){
-    DEFINES+=DEBUG
-    TARGET = $$join(TARGET,,,d)
-    message("OMOptimLibDebug")
-}
-
-win32 {
-    include(OMOptim.windowsconfig.in)
-}else {
-    include(OMOptim.config)
-}
-
 DESTDIR = ../bin
 DEPENDPATH += ../bin
 
@@ -33,7 +21,6 @@ INCLUDEPATH += . \
               ../Core/Infos \
               ../Core/Modelica \
               ../Core/OMC \
-              ../Core/OpenModelica \
               ../Core/Problems \
               ../Core/Tools \
               ../Core/Util \
@@ -421,3 +408,14 @@ SOURCES += ../Core/OptObjective.cpp \
     ../Core/Util/Utilities.cpp
     #../Core/ModPlusTherExeCtrl.cpp
 
+CONFIG(debug, debug|release){
+    DEFINES+=DEBUG
+    TARGET = $$join(TARGET,,,d)
+    message("OMOptimLibDebug")
+}
+
+win32 {
+    include(OMOptim.windowsconfig.in)
+}else {
+    include(OMOptim.config)
+}


### PR DESCRIPTION
    There is an `OpenModelica.h` file in `OMOptim/Core/OpenModelica`
    There is an `openmodelica.h` file in `<omc_build_dir>/include/omc/c`

    On case insensitive systems which one is included depends on which
    include directory comes first.

    This is why include directories should be kept to minimal and prefixed.

  - The include directory `/Core/OpenModelica` is now removed from OMOptimLib
    project configuration. Instead `Core` (existing) include dir is used
    and all corresponding includes are prefixed.
      OpenModelica.h -> OpenModelica/OpenModelica.h
      OpenModelicaParameters.h -> OpenModelica/OpenModelicaParameters.h
      ....

  - I have moved config files inclusion after own defines. This is done
    to put OMOptim's include directories before OpenModelica's (include/c/).
    While the current issue is fixed by prefixing the includes it is still
    a good idea to put own include dirs before others.

    It is better if all includes are prefixed like this. But I can not do that
    now. I have almost forgotten what I originally set out to do. Which
    was, just wrap fread() with omc_fread() in OpenModelica repo. Seemed
    easy and here we are fixing OMOptim :).