### PR TITLE
Remove declarations of error functions.

### DIFF
--- a/OMOptim/main.cpp
+++ b/OMOptim/main.cpp
@@ -68,8 +68,6 @@
 #include <omniORB4/CORBA.h>
 
 #include "util/omc_error.h"
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
 
 CORBA::ORB_var orb;
 


### PR DESCRIPTION
  - They are not needed anymore. If they need to change they can now be
    assigned in the main function or somewhere else. They do not need to
    be declared globably.

    They also have a default value now in OpenModelicaRuntimeC which is
    the same as what was used here. So no more changes are needed here.