### PR TITLE
Fix some compilation warnings

### DIFF
--- a/OMOptim/Core/OMC/commandcompletion.cpp
+++ b/OMOptim/Core/OMC/commandcompletion.cpp
@@ -260,7 +260,7 @@ namespace IAEX
             }
         }
 
-        return QString::null;
+        return QString();
     }
 
     /*

--- a/OMOptim/Core/OMC/commandunit.h
+++ b/OMOptim/Core/OMC/commandunit.h
@@ -86,7 +86,7 @@ namespace IAEX
             if( datafields_.contains( fieldID ))
                 return datafields_[fieldID];
             else
-                return QString::null;
+                return QString();
         }
         void addDataField( QString fieldID, QString data )
         {

--- a/OMOptim/GUI/Tabs/TabOMC.cpp
+++ b/OMOptim/GUI/Tabs/TabOMC.cpp
@@ -377,7 +377,7 @@ void TabOMC::returnPressed()
     currentCommand_ = -1;
 
     // remove any newline
-    commandText.simplified();
+    commandText = commandText.simplified();
 
     // if 'quit()' exit WinMosh
     if( commandText == "quit()" )

--- a/OMOptim/GUI/Widgets/WidgetMooPointsList.cpp
+++ b/OMOptim/GUI/Widgets/WidgetMooPointsList.cpp
@@ -216,7 +216,7 @@ void WidgetMooPointsList::exportSelectedPoints()
         QString csvPath = QFileDialog::getSaveFileName(
                     this,
                     "MO - Export optimum points",
-                    QString::null,
+                    QString(),
                     "CSV file (*.csv)" );
 
         if(!csvPath.isNull())

--- a/OMOptimBasis/GUI/Widgets/WidgetTableVar.cpp
+++ b/OMOptimBasis/GUI/Widgets/WidgetTableVar.cpp
@@ -119,7 +119,7 @@ void WidgetTableOptVar::exportCSV()
     QString csvPath = QFileDialog::getSaveFileName(
                 this,
                 "MO - Export variables",
-                QString::null,
+                QString(),
                 "CSV file (*.csv)" );
 
     if(!csvPath.isNull())


### PR DESCRIPTION
- QString::null is obsolete, use QString() instead.
- Don't ignore the return value of QString::simplified(),
  it doesn't change the string but returns a new string.