### PR TITLE
Fix OMOptim unix build: drop dead CORBA step, bump ParadisEO CMake min

### DIFF
--- a/OMOptim/build/Makefile.unix.in
+++ b/OMOptim/build/Makefile.unix.in
@@ -20,17 +20,9 @@ $(LIBNAME): MakefileLib
 
 build: $(LIBNAME) $(NAME)
 
-../Core/OMC/omc_communication.cpp: omc_communication.cc
-	ln -s ../../build/omc_communication.cc $@
-../Core/OMC/omc_communication.h: omc_communication.h
-	ln -s ../../build/omc_communication.h $@
-omc_communication.cc: @OPENMODELICAHOME@/share/omc/omc_communication.idl
-	@IDLCMD@ $<
-omc_communication.h: omc_communication.cc
-
-Makefile: $(NAME).pro $(NAME).config ../Core/OMC/omc_communication.cpp ../Core/OMC/omc_communication.h
+Makefile: $(NAME).pro $(NAME).config
 	$(QMAKE) $< -o $@
-MakefileLib: $(LIBNAME).pro $(NAME).config ../Core/OMC/omc_communication.cpp ../Core/OMC/omc_communication.h
+MakefileLib: $(LIBNAME).pro $(NAME).config
 	$(QMAKE) $< -o $@
 Makefile.unix: Makefile.unix.in
 	(cd $(top_dir) && ./config.status)
@@ -40,4 +32,4 @@ $(NAME).config: $(NAME).config.in
 clean:
 	test ! -f Makefile || $(MAKE) -f Makefile clean
 	test ! -f MakefileLib || $(MAKE) -f MakefileLib clean
-	rm -rf *.o *.a moc_* OMOptim release/ Makefile MakefileLib  omc_communication.* ../Core/OMC/omc_communication.*
+	rm -rf *.o *.a moc_* OMOptim release/ Makefile MakefileLib

--- a/ParadisEO-2.0.1/CMakeLists.txt
+++ b/ParadisEO-2.0.1/CMakeLists.txt
@@ -4,7 +4,7 @@
 ### 0) Check the CMake version
 ######################################################################################
 
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 ######################################################################################
 ### 1) Define the project

--- a/ParadisEO-2.0.1/eo/CMakeLists.txt
+++ b/ParadisEO-2.0.1/eo/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 ######################################################################################
 ### 0) If you want to set your variables in eo-conf.cmake and avoid the cmd line

--- a/ParadisEO-2.0.1/eo/src/pyeo/CMakeLists.txt
+++ b/ParadisEO-2.0.1/eo/src/pyeo/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 # ----------------------------------------------------------------------------
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 PROJECT(PyEO)
 


### PR DESCRIPTION
The resurrected OMOptim links libOpenModelicaCompiler in-process and no longer uses the CORBA omc_communication stubs, but Makefile.unix.in still generated them. With @IDLCMD@ empty, make tried to execute the .idl file directly and failed (Permission denied, Error 127). Drop the omc_communication targets and the Makefile/MakefileLib dependencies on them.

Bump cmake_minimum_required in the bundled ParadisEO-2.0.1 (top-level, eo, pyeo) from 2.6/2.8 to 3.5, since CMake >= 4 removed compatibility with CMake < 3.5 and hard-errors during configure.

Refs #14506