### PR TITLE
Define OM_HAVE_PTHREADS for the OMOptim build

### DIFF
--- a/OMOptim/build/OMOptim.pro
+++ b/OMOptim/build/OMOptim.pro
@@ -58,6 +58,12 @@ win32 {
     include(OMOptim.config)
 }
 
+# OMOptim drives the OpenModelica compiler in-process and uses the
+# MMC_TRY_TOP/threadData macros, which reference threadData->parentMutex.
+# That member only exists when OM_HAVE_PTHREADS is defined (as OMEdit does),
+# so define it here for all platforms.
+DEFINES += OM_HAVE_PTHREADS
+
 CONFIG(debug, debug|release): PRE_TARGETDEPS += ../bin/libOMOptimd.a
 else:CONFIG(release, debug|release): PRE_TARGETDEPS += ../bin/libOMOptim.a
 

--- a/OMOptim/build/OMOptimLib.pro
+++ b/OMOptim/build/OMOptimLib.pro
@@ -445,3 +445,9 @@ win32 {
 }else {
     include(OMOptim.config)
 }
+
+# OMOptim drives the OpenModelica compiler in-process and uses the
+# MMC_TRY_TOP/threadData macros, which reference threadData->parentMutex.
+# That member only exists when OM_HAVE_PTHREADS is defined (as OMEdit does),
+# so define it here for all platforms.
+DEFINES += OM_HAVE_PTHREADS


### PR DESCRIPTION
OMOptim now drives libOpenModelicaCompiler in-process and uses the MMC_TRY_TOP/MMC_TRY_TOP_INTERNAL macros (MOomc.cpp, main.cpp). Those macros reference threadData->parentMutex and call pthread_mutex_init, but parentMutex only exists in struct threadData_s when OM_HAVE_PTHREADS is defined. OMEdit defines it (OMEdit.config.pre.pri); OMOptim did not, so the compiler reported "no member named 'parentMutex' in 'threadData_s'" (seen first on the Windows/UCRT64 build, but the unix build hits it too).

Define OM_HAVE_PTHREADS unconditionally in OMOptim.pro and OMOptimLib.pro, matching OMEdit.

Refs #14506