### PR TITLE
Link libOpenModelicaCompiler in the OMOptim Windows build

### DIFF
--- a/OMOptim/build/OMOptim.windowsconfig.in
+++ b/OMOptim/build/OMOptim.windowsconfig.in
@@ -47,15 +47,11 @@ CONFIG(debug, debug|release){
   ISMINGW32 = $$find(UNAME, MINGW32)
   message(uname: $$UNAME)
   count( ISMINGW32, 1 ) {
-    CORBAINC = $$(OMDEV)/lib/omniORB-4.2.0-mingw32/include
-    CORBALIBS = -L$$(OMDEV)/lib/omniORB-4.2.0-mingw32/lib/x86_win32 -lomniORB420_rt -lomnithread40_rt -lomniDynamic420_rt
     DEFINES += __x86__ \
                __NT__ \
                __OSVERSION__=4 \
                __WIN32__
   } else {
-    CORBAINC = $$(OMDEV)/lib/omniORB-4.2.0-mingw64/include
-    CORBALIBS = -L$$(OMDEV)/lib/omniORB-4.2.0-mingw64/lib/x86_win32 -lomniORB420_rt -lomnithread40_rt -lomniDynamic420_rt
     DEFINES += __x86__ \
 	           __x86_64__ \
 	           __NT__ \
@@ -66,8 +62,7 @@ CONFIG(debug, debug|release){
   }
 
 
-INCLUDEPATH += $${CORBAINC} \
-               $$(OMBUILDDIR)/include/omplot/qwt \
+INCLUDEPATH += $$(OMBUILDDIR)/include/omplot/qwt \
                $$(OMBUILDDIR)/include/omc/c/ \
                ../../ParadisEO-2.0.1/eo/src \
                ../../ParadisEO-2.0.1/eo/src/utils \
@@ -76,11 +71,11 @@ INCLUDEPATH += $${CORBAINC} \
 
 ### LIBRARIES (order has an impact !!)
 CONFIG(debug, debug|release){
-    LIBS += $${CORBALIBS} -L$$(OMBUILDDIR)/lib/omc -lOMOptimBasisd -lomqwtd
+    LIBS += -L$$(OMBUILDDIR)/lib/omc -lOMOptimBasisd -lomqwtd
 }else {
-    LIBS += $${CORBALIBS} -L$$(OMBUILDDIR)/lib/omc -lOMOptimBasis -lomqwt
+    LIBS += -L$$(OMBUILDDIR)/lib/omc -lOMOptimBasis -lomqwt
 }
 
-LIBS += -lOpenModelicaRuntimeC -lomcgc \
+LIBS += -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lomcgc \
     -L../../ParadisEO-2.0.1/build/eo/lib -leo -leoutils \
     -L../../ParadisEO-2.0.1/build/moeo/lib -lmoeo


### PR DESCRIPTION
The resurrected OMOptim calls the in-process compiler entry points (omc_Main_init, omc_Main_handleCommand, omc_Main_setWindowsPaths, omc_System_initGarbageCollector) from MOomc.cpp, but the Windows config only linked -lOpenModelicaRuntimeC -lomcgc, so the link failed with undefined references to those omc_Main_* symbols.

Add -lOpenModelicaCompiler (ahead of the runtime/gc libs) to match the unix config, and drop the now-dead omniORB/CORBA include and link flags (CORBAINC/CORBALIBS) since OMOptim no longer uses CORBA.

Refs #14506