### PR TITLE
Fix clang detection on Windows

### DIFF
--- a/OMOptim/build/OMOptim.windowsconfig.in
+++ b/OMOptim/build/OMOptim.windowsconfig.in
@@ -2,8 +2,7 @@
 QMAKE_LFLAGS += -Wl,--enable-auto-import
 QMAKE_CXXFLAGS_WARN_OFF += -Wunused-parameter
 
-_cxx = $$(CXX)
-contains(_cxx, clang++) {
+equals(QMAKE_CXX, clang++) {
   message("Found clang++ on windows in $CXX, removing unknown flags: -fno-keep-inline-dllexport")
   QMAKE_CFLAGS -= -fno-keep-inline-dllexport
   QMAKE_CXXFLAGS -= -fno-keep-inline-dllexport

--- a/OMOptimBasis/build/OMOptimBasis.windowsconfig.in
+++ b/OMOptimBasis/build/OMOptimBasis.windowsconfig.in
@@ -3,8 +3,7 @@
 QMAKE_LFLAGS += -Wl,--enable-auto-import
 QMAKE_CXXFLAGS_WARN_OFF += -Wunused-parameter
 
-_cxx = $$(CXX)
-contains(_cxx, clang++) {
+equals(QMAKE_CXX, clang++) {
   message("Found clang++ on windows in $CXX, removing unknown flags: -fno-keep-inline-dllexport")
   QMAKE_CFLAGS -= -fno-keep-inline-dllexport
   QMAKE_CXXFLAGS -= -fno-keep-inline-dllexport


### PR DESCRIPTION
## Issue

Windows builds with clang++ and Makefiles are broken, see https://github.com/OpenModelica/OpenModelica/pull/16158.

## Changes

* Broken regex argument `clang++` in `contains()`. Use `equals` where second argument is a plain string.