### PR TITLE
Fix clang++ detection on Windows

### DIFF
--- a/OMOptim/build/OMOptim.windowsconfig.in
+++ b/OMOptim/build/OMOptim.windowsconfig.in
@@ -2,7 +2,8 @@
 QMAKE_LFLAGS += -Wl,--enable-auto-import
 QMAKE_CXXFLAGS_WARN_OFF += -Wunused-parameter
 
-equals(QMAKE_CXX, clang++) {
+_cxx = $$(CXX)
+equals(_cxx, clang++) {
   message("Found clang++ on windows in $CXX, removing unknown flags: -fno-keep-inline-dllexport")
   QMAKE_CFLAGS -= -fno-keep-inline-dllexport
   QMAKE_CXXFLAGS -= -fno-keep-inline-dllexport

--- a/OMOptimBasis/build/OMOptimBasis.windowsconfig.in
+++ b/OMOptimBasis/build/OMOptimBasis.windowsconfig.in
@@ -3,7 +3,8 @@
 QMAKE_LFLAGS += -Wl,--enable-auto-import
 QMAKE_CXXFLAGS_WARN_OFF += -Wunused-parameter
 
-equals(QMAKE_CXX, clang++) {
+_cxx = $$(CXX)
+equals(_cxx, clang++) {
   message("Found clang++ on windows in $CXX, removing unknown flags: -fno-keep-inline-dllexport")
   QMAKE_CFLAGS -= -fno-keep-inline-dllexport
   QMAKE_CXXFLAGS -= -fno-keep-inline-dllexport


### PR DESCRIPTION
## Issue

Still the same build error on Windows:

```
clang++: error: unknown argument: '-fno-keep-inline-dllexport'
```

## Changes

Compare against the `CXX` env var, not `QMAKE_CXX`.