### PR TITLE
Remove corba idlcmd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,6 @@ AC_INIT([OMOptim],[dev],[https://trac.openmodelica.org/OpenModelica],[openmodeli
 AC_SUBST(OMOPTIMCXX)
 AC_SUBST(APP)
 AC_SUBST(EXE)
-AC_SUBST(IDLCMD)
 AC_SUBST(RPATH_QMAKE)
 AC_SUBST(host_short)
 AC_SUBST(SOURCE_REVISION)


### PR DESCRIPTION
## Issue

For https://github.com/OpenModelica/OpenModelica/pull/16475.

## Changes

Remove the leftover IDLCMD substitution
common/m4/corba.m4 was the only thing that ever set IDLCMD (the omniidl
command line), and it is gone. Nothing substitutes @IDLCMD@ into any of the
files listed in AC_OUTPUT, so the AC_SUBST only declared an always-empty
variable.